### PR TITLE
Only activiate when the game is Morrowind

### DIFF
--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -43,7 +43,10 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         return mobase.VersionInfo(2, 0, 0, mobase.ReleaseType.final)
 
     def isActive(self):
-        return True
+        if self.__organizer.managedGame().gameName() == "Morrowind":
+            return True
+        else:
+            return False
 
     def settings(self):
         return []

--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -43,10 +43,7 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         return mobase.VersionInfo(2, 0, 0, mobase.ReleaseType.final)
 
     def isActive(self):
-        if self.__organizer.managedGame().gameName() == "Morrowind":
-            return True
-        else:
-            return False
+        return (self.__organizer.managedGame().gameName() == "Morrowind")
 
     def settings(self):
         return []


### PR DESCRIPTION
This is just something I created for myself so that I dont see the plugin option when not in my Morrowind instance. 