### PR TITLE
Changes for MO2 2.5.x

### DIFF
--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -27,7 +27,7 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         self.__organizer = organizer
         if sys.version_info < (3, 6):
             qCritical(OpenMWExportPlugin.tr("OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.").format("3.6", ".".join(map(str, sys.version_info[:3]))))
-            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Incompatible Python version."), OpenMWExportPlugin.tr("This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.").format("3.6", ".".join(map(str, sys.version_info[:3])), "2.1.6"))
+            QMessageBox.critical(self._parentWidget(), OpenMWExportPlugin.tr("Incompatible Python version."), OpenMWExportPlugin.tr("This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.").format("3.6", ".".join(map(str, sys.version_info[:3])), "2.1.6"))
             return False
         if self.__organizer.appVersion() >= mobase.VersionInfo(2, 3, 1):
             self.__nexusBridge = self.__organizer.createNexusBridge()
@@ -66,9 +66,6 @@ class OpenMWExportPlugin(mobase.IPluginTool):
 
     def icon(self):
         return QIcon("plugins/openmw.ico")
-
-    def setParentWidget(self, widget):
-        self.__parentWidget = widget
     
     def display(self):
         if self.__organizer.appVersion() >= mobase.VersionInfo(2, 4, 0):
@@ -80,16 +77,16 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         # We can't do that directly, so instead we just test if the current game is Morrowind
         game = self.__organizer.managedGame()
         if game.gameName() != "Morrowind":
-            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Incompatible game"), OpenMWExportPlugin.tr("(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin."))
+            QMessageBox.critical(self._parentWidget(), OpenMWExportPlugin.tr("Incompatible game"), OpenMWExportPlugin.tr("(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin."))
             return
         # Give the user the opportunity to abort
-        confirmationButton = QMessageBox.question(self.__parentWidget, OpenMWExportPlugin.tr("Before starting export..."), OpenMWExportPlugin.tr("Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever."), QMessageBox.StandardButton(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel))
+        confirmationButton = QMessageBox.question(self._parentWidget(), OpenMWExportPlugin.tr("Before starting export..."), OpenMWExportPlugin.tr("Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever."), QMessageBox.StandardButton(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel))
         if confirmationButton != QMessageBox.StandardButton.Ok:
             return
         # Get the path to the OpenMW.cfg file
         configPath = self.__getOpenMWConfigPath()
         if not configPath.is_file():
-            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Config file not specified"), OpenMWExportPlugin.tr("No config file was specified"))
+            QMessageBox.critical(self._parentWidget(), OpenMWExportPlugin.tr("Config file not specified"), OpenMWExportPlugin.tr("No config file was specified"))
             return
         # Clear out the existing data= and content= lines from openmw.cfg
         self.__clearOpenMWConfig(configPath)
@@ -110,7 +107,7 @@ class OpenMWExportPlugin(mobase.IPluginTool):
             # actually write out the list
             for pluginIndex in range(len(loadOrder)):
                 openmwcfg.write("content=" + loadOrder[pluginIndex] + "\n")
-        QMessageBox.information(self.__parentWidget, OpenMWExportPlugin.tr("OpenMW Export Complete"), OpenMWExportPlugin.tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))
+        QMessageBox.information(self._parentWidget(), OpenMWExportPlugin.tr("OpenMW Export Complete"), OpenMWExportPlugin.tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))
     
     @staticmethod
     def tr(str):
@@ -164,7 +161,7 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         if defaultLocation.is_file():
             return defaultLocation
         # If we've got this far, then the user is doing something very weird, so they can find it themselves.
-        return Path(QFileDialog.getOpenFileName(self.__parentWidget, OpenMWExportPlugin.tr("Locate OpenMW Config File"), ".", "OpenMW Config File (openmw.cfg)")[0])
+        return Path(QFileDialog.getOpenFileName(self._parentWidget(), OpenMWExportPlugin.tr("Locate OpenMW Config File"), ".", "OpenMW Config File (openmw.cfg)")[0])
     
     def __checkForUpdate(self, mainWindow):
         self.__nexusBridge.requestDescription("Morrowind", 45642, None)

--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -105,7 +105,7 @@ class OpenMWExportPlugin(mobase.IPluginTool):
     
     def __processMod(self, configFile, modName):
         state = self.__organizer.modList().state(modName)
-        if (state & 0x2) != 0 or modName == "Overwrite":
+        if (state & mobase.ModState.ACTIVE) != 0 or modName == "Overwrite":
             path = self.__organizer.modList().getMod(modName).absolutePath()
             configLine = self.__processDataPath(path)
             configFile.write(configLine)

--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -9,9 +9,9 @@
 from pathlib import Path
 import sys
 
-from PyQt5.QtCore import QCoreApplication, QStandardPaths, QUrl, qCritical
-from PyQt5.QtGui import QDesktopServices, QIcon
-from PyQt5.QtWidgets import QFileDialog, QMessageBox
+from PyQt6.QtCore import QCoreApplication, QStandardPaths, QUrl, qCritical
+from PyQt6.QtGui import QDesktopServices, QIcon
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
 
 if "mobase" not in sys.modules:
     import mobase
@@ -26,8 +26,8 @@ class OpenMWExportPlugin(mobase.IPluginTool):
     def init(self, organizer):
         self.__organizer = organizer
         if sys.version_info < (3, 6):
-            qCritical(self.__tr("OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.").format("3.6", ".".join(map(str, sys.version_info[:3]))))
-            QMessageBox.critical(self.__parentWidget, self.__tr("Incompatible Python version."), self.__tr("This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.").format("3.6", ".".join(map(str, sys.version_info[:3])), "2.1.6"))
+            qCritical(OpenMWExportPlugin.tr("OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.").format("3.6", ".".join(map(str, sys.version_info[:3]))))
+            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Incompatible Python version."), OpenMWExportPlugin.tr("This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.").format("3.6", ".".join(map(str, sys.version_info[:3])), "2.1.6"))
             return False
         if self.__organizer.appVersion() >= mobase.VersionInfo(2, 3, 1):
             self.__nexusBridge = self.__organizer.createNexusBridge()
@@ -42,10 +42,10 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         return "AnyOldName3"
 
     def description(self):
-        return self.__tr("Transfers mod list (left pane) to data fields in OpenMW.cfg and plugin list (right pane, plugins tab) to content fields in OpenMW.cfg. This allows you to run OpenMW with the current profile's setup from outside of Mod Organizer")
+        return OpenMWExportPlugin.tr("Transfers mod list (left pane) to data fields in OpenMW.cfg and plugin list (right pane, plugins tab) to content fields in OpenMW.cfg. This allows you to run OpenMW with the current profile's setup from outside of Mod Organizer")
 
     def version(self):
-        return mobase.VersionInfo(3, 1, 0, mobase.ReleaseType.BETA)
+        return mobase.VersionInfo(4, 0, 0, mobase.ReleaseType.ALPHA)
 
     def requirements(self):
         return [
@@ -59,10 +59,10 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         return []
 
     def displayName(self):
-        return self.__tr("Export to OpenMW")
+        return OpenMWExportPlugin.tr("Export to OpenMW")
 
     def tooltip(self):
-        return self.__tr("Exports the current mod list and plugin load order to OpenMW.cfg")
+        return OpenMWExportPlugin.tr("Exports the current mod list and plugin load order to OpenMW.cfg")
 
     def icon(self):
         return QIcon("plugins/openmw.ico")
@@ -80,16 +80,16 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         # We can't do that directly, so instead we just test if the current game is Morrowind
         game = self.__organizer.managedGame()
         if game.gameName() != "Morrowind":
-            QMessageBox.critical(self.__parentWidget, self.__tr("Incompatible game"), self.__tr("(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin."))
+            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Incompatible game"), OpenMWExportPlugin.tr("(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin."))
             return
         # Give the user the opportunity to abort
-        confirmationButton = QMessageBox.question(self.__parentWidget, self.__tr("Before starting export..."), self.__tr("Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever."), QMessageBox.StandardButtons(QMessageBox.Ok | QMessageBox.Cancel))
-        if confirmationButton != QMessageBox.Ok:
+        confirmationButton = QMessageBox.question(self.__parentWidget, OpenMWExportPlugin.tr("Before starting export..."), OpenMWExportPlugin.tr("Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever."), QMessageBox.StandardButton(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel))
+        if confirmationButton != QMessageBox.StandardButton.Ok:
             return
         # Get the path to the OpenMW.cfg file
         configPath = self.__getOpenMWConfigPath()
         if not configPath.is_file():
-            QMessageBox.critical(self.__parentWidget, self.__tr("Config file not specified"), self.__tr("No config file was specified"))
+            QMessageBox.critical(self.__parentWidget, OpenMWExportPlugin.tr("Config file not specified"), OpenMWExportPlugin.tr("No config file was specified"))
             return
         # Clear out the existing data= and content= lines from openmw.cfg
         self.__clearOpenMWConfig(configPath)
@@ -110,9 +110,10 @@ class OpenMWExportPlugin(mobase.IPluginTool):
             # actually write out the list
             for pluginIndex in range(len(loadOrder)):
                 openmwcfg.write("content=" + loadOrder[pluginIndex] + "\n")
-        QMessageBox.information(self.__parentWidget, self.__tr("OpenMW Export Complete"), self.__tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))
+        QMessageBox.information(self.__parentWidget, OpenMWExportPlugin.tr("OpenMW Export Complete"), OpenMWExportPlugin.tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))
     
-    def __tr(self, str):
+    @staticmethod
+    def tr(str):
         return QCoreApplication.translate("OpenMWExportPlugin", str)
     
     def __processMod(self, configFile, modName):
@@ -159,11 +160,11 @@ class OpenMWExportPlugin(mobase.IPluginTool):
         shutil.move(tempFilePath, configPath)
     
     def __getOpenMWConfigPath(self):
-        defaultLocation = Path(QStandardPaths.locate(QStandardPaths.DocumentsLocation, str(Path("My Games", "OpenMW", "openmw.cfg"))))
+        defaultLocation = Path(QStandardPaths.locate(QStandardPaths.StandardLocation.DocumentsLocation, str(Path("My Games", "OpenMW", "openmw.cfg"))))
         if defaultLocation.is_file():
             return defaultLocation
         # If we've got this far, then the user is doing something very weird, so they can find it themselves.
-        return Path(QFileDialog.getOpenFileName(self.__parentWidget, self.__tr("Locate OpenMW Config File"), ".", "OpenMW Config File (openmw.cfg)")[0])
+        return Path(QFileDialog.getOpenFileName(self.__parentWidget, OpenMWExportPlugin.tr("Locate OpenMW Config File"), ".", "OpenMW Config File (openmw.cfg)")[0])
     
     def __checkForUpdate(self, mainWindow):
         self.__nexusBridge.requestDescription("Morrowind", 45642, None)
@@ -171,8 +172,8 @@ class OpenMWExportPlugin(mobase.IPluginTool):
     def __onDescriptionReceived(self, gameName, modID, userData, resultData):
         version = mobase.VersionInfo(resultData["version"])
         if self.version() < version:
-            response = QMessageBox.question(self._parentWidget(), self.__tr("Plugin update available"), self.__tr("{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?").format(self.displayName(), self.version(), version))
-            if response == QMessageBox.Yes:
+            response = QMessageBox.question(self._parentWidget(), OpenMWExportPlugin.tr("Plugin update available"), OpenMWExportPlugin.tr("{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?").format(self.displayName(), self.version(), version))
+            if response == QMessageBox.StandardButton.Yes:
                 QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/morrowind/mods/45642"))
     
 def createPlugin():

--- a/OpenMWExport_en.ts
+++ b/OpenMWExport_en.ts
@@ -4,87 +4,72 @@
   <context>
     <name>OpenMWExportPlugin</name>
     <message>
-      <location filename="OpenMWExport.py" line="29" />
-      <source>OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="OpenMWExport.py" line="30" />
-      <source>Incompatible Python version.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="OpenMWExport.py" line="30" />
-      <source>This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="OpenMWExport.py" line="45" />
+      <location filename="OpenMWExport.py" line="40" />
       <source>Transfers mod list (left pane) to data fields in OpenMW.cfg and plugin list (right pane, plugins tab) to content fields in OpenMW.cfg. This allows you to run OpenMW with the current profile's setup from outside of Mod Organizer</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="62" />
+      <location filename="OpenMWExport.py" line="57" />
       <source>Export to OpenMW</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="65" />
+      <location filename="OpenMWExport.py" line="60" />
       <source>Exports the current mod list and plugin load order to OpenMW.cfg</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="80" />
+      <location filename="OpenMWExport.py" line="70" />
       <source>Incompatible game</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="80" />
+      <location filename="OpenMWExport.py" line="70" />
       <source>(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="83" />
+      <location filename="OpenMWExport.py" line="73" />
       <source>Before starting export...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="83" />
+      <location filename="OpenMWExport.py" line="73" />
       <source>Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="89" />
+      <location filename="OpenMWExport.py" line="79" />
       <source>Config file not specified</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="89" />
+      <location filename="OpenMWExport.py" line="79" />
       <source>No config file was specified</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="110" />
+      <location filename="OpenMWExport.py" line="100" />
       <source>OpenMW Export Complete</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="110" />
+      <location filename="OpenMWExport.py" line="100" />
       <source>The export to OpenMW completed successfully. The current setup was saved to {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="164" />
+      <location filename="OpenMWExport.py" line="150" />
       <source>Locate OpenMW Config File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="172" />
+      <location filename="OpenMWExport.py" line="158" />
       <source>Plugin update available</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="172" />
+      <location filename="OpenMWExport.py" line="158" />
       <source>{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?</source>
       <translation type="unfinished" />
     </message>

--- a/OpenMWExport_en.ts
+++ b/OpenMWExport_en.ts
@@ -1,91 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="2.0">
-<context>
+<!DOCTYPE TS>
+<TS version="2.0">
+  <context>
     <name>OpenMWExportPlugin</name>
     <message>
-        <location filename="OpenMWExport.py" line="45"/>
-        <source>Transfers mod list (left pane) to data fields in OpenMW.cfg and plugin list (right pane, plugins tab) to content fields in OpenMW.cfg. This allows you to run OpenMW with the current profile&apos;s setup from outside of Mod Organizer</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="29" />
+      <source>OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="62"/>
-        <source>Export to OpenMW</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="30" />
+      <source>Incompatible Python version.</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="65"/>
-        <source>Exports the current mod list and plugin load order to OpenMW.cfg</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="30" />
+      <source>This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="83"/>
-        <source>Incompatible game</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="45" />
+      <source>Transfers mod list (left pane) to data fields in OpenMW.cfg and plugin list (right pane, plugins tab) to content fields in OpenMW.cfg. This allows you to run OpenMW with the current profile's setup from outside of Mod Organizer</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="83"/>
-        <source>(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin.</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="62" />
+      <source>Export to OpenMW</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="86"/>
-        <source>Before starting export...</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="65" />
+      <source>Exports the current mod list and plugin load order to OpenMW.cfg</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="86"/>
-        <source>Before starting the export to OpenMW, please ensure you&apos;ve backed up anything in OpenMW.cfg which you do not want to risk losing forever.</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="83" />
+      <source>Incompatible game</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="92"/>
-        <source>Config file not specified</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="83" />
+      <source>(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin.</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="92"/>
-        <source>No config file was specified</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="86" />
+      <source>Before starting export...</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="113"/>
-        <source>OpenMW Export Complete</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="86" />
+      <source>Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever.</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="113"/>
-        <source>The export to OpenMW completed successfully. The current setup was saved to {0}</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="92" />
+      <source>Config file not specified</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="166"/>
-        <source>Locate OpenMW Config File</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="92" />
+      <source>No config file was specified</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="29"/>
-        <source>OpenMWExport plugin requires a Python {0} interpreter or newer, but is running on a Python {1} interpreter.</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="113" />
+      <source>OpenMW Export Complete</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="30"/>
-        <source>Incompatible Python version.</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="113" />
+      <source>The export to OpenMW completed successfully. The current setup was saved to {0}</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="30"/>
-        <source>This version of the OpenMW Export plugin requires a Python {0} interpreter or newer, but Mod Organizer has provided a Python {1} interpreter. Mod Organizer {2} is the earliest compatible version. You should check for an update.</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="167" />
+      <source>Locate OpenMW Config File</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="174"/>
-        <source>Plugin update available</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="175" />
+      <source>Plugin update available</source>
+      <translation type="unfinished" />
     </message>
     <message>
-        <location filename="OpenMWExport.py" line="174"/>
-        <source>{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?</source>
-        <translation type="unfinished"></translation>
+      <location filename="OpenMWExport.py" line="175" />
+      <source>{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?</source>
+      <translation type="unfinished" />
     </message>
-</context>
+  </context>
 </TS>

--- a/OpenMWExport_en.ts
+++ b/OpenMWExport_en.ts
@@ -34,57 +34,57 @@
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="83" />
+      <location filename="OpenMWExport.py" line="80" />
       <source>Incompatible game</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="83" />
+      <location filename="OpenMWExport.py" line="80" />
       <source>(At least when this plugin is being written) OpenMW only supports game data designed for the Morrowind engine. The game being managed is not Morrowind, so the export will abort. If you think you know better than this message, update this plugin.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="86" />
+      <location filename="OpenMWExport.py" line="83" />
       <source>Before starting export...</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="86" />
+      <location filename="OpenMWExport.py" line="83" />
       <source>Before starting the export to OpenMW, please ensure you've backed up anything in OpenMW.cfg which you do not want to risk losing forever.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="92" />
+      <location filename="OpenMWExport.py" line="89" />
       <source>Config file not specified</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="92" />
+      <location filename="OpenMWExport.py" line="89" />
       <source>No config file was specified</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="113" />
+      <location filename="OpenMWExport.py" line="110" />
       <source>OpenMW Export Complete</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="113" />
+      <location filename="OpenMWExport.py" line="110" />
       <source>The export to OpenMW completed successfully. The current setup was saved to {0}</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="167" />
+      <location filename="OpenMWExport.py" line="164" />
       <source>Locate OpenMW Config File</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="175" />
+      <location filename="OpenMWExport.py" line="172" />
       <source>Plugin update available</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="OpenMWExport.py" line="175" />
+      <location filename="OpenMWExport.py" line="172" />
       <source>{0} can be updated from version {1} to {2}. Do you want to open the download page in your browser?</source>
       <translation type="unfinished" />
     </message>

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@ param (
     [switch] $Release
 )
 
-python -m PyQt5.pylupdate_main OpenMWExport.py -ts OpenMWExport_en.ts
+pylupdate6 OpenMWExport.py -ts OpenMWExport_en.ts
 
 if (!$?) {
     Write-Error "pylupdate failed." -ErrorAction Stop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Stubs for linter and autocompletion. Automatically includes PyQt5 stubs for latest MO2 release.
-mobase-stubs
+mobase-stubs ~= 2.5.0.dev10
 mypy
 # MO2's PyQt5 gets used for builds. We only need the pylupdate_main subpackage, but that can't be installed on its own.
-PyQt5
+PyQt6


### PR DESCRIPTION
MO2 2.5.x switches from PyQt5 to PyQt6, which isn't entirely backwards compatible. This means breaking changes, and therefore also gives an opportunity to get rid of ugly code that only exists to make old versions of MO2 work.