### PR TITLE
Refactor/suport for .omw* files via dummy esp (thanks ignamiranda), logging, optional preformance mode, 

### DIFF
--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -101,6 +101,12 @@ class OpenMWExportPlugin(mobase.IPluginTool):
             return
         # Clear out the existing data= and content= lines from openmw.cfg
         self.__clearOpenMWConfig(configPath)
+        # get already enabled groundcover plugins
+        existing_groundcovers = set()
+        with configPath.open("r", encoding="utf-8") as openmwcfg:
+            for line in openmwcfg:
+                if line.lower().startswith("groundcover="):
+                    existing_groundcovers.add(line.strip().split('=')[1].lower())
         with configPath.open("a", encoding="utf-8") as openmwcfg:
             # write out data directories
             openmwcfg.write(self.__processDataPath(game.dataDirectory().absolutePath()))
@@ -117,7 +123,9 @@ class OpenMWExportPlugin(mobase.IPluginTool):
                     loadOrder[loadIndex] = plugin
             # actually write out the list
             for pluginIndex in range(len(loadOrder)):
-                openmwcfg.write("content=" + loadOrder[pluginIndex] + "\n")
+                pluginName = loadOrder[pluginIndex]
+                if pluginName.lower() not in existing_groundcovers:
+                    openmwcfg.write("content=" + pluginName + "\n")
         QMessageBox.information(self._parentWidget(), OpenMWExportPlugin.tr("OpenMW Export Complete"), OpenMWExportPlugin.tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))
     
     @staticmethod

--- a/OpenMWExport.py
+++ b/OpenMWExport.py
@@ -124,6 +124,8 @@ class OpenMWExportPlugin(mobase.IPluginTool):
             # actually write out the list
             for pluginIndex in range(len(loadOrder)):
                 pluginName = loadOrder[pluginIndex]
+                if pluginName.lower().endswith(".omwaddon.esp") or pluginName.lower().endswith(".omwscripts.esp"):
+                    pluginName = pluginName.rsplit('.', 1)[0]
                 if pluginName.lower() not in existing_groundcovers:
                     openmwcfg.write("content=" + pluginName + "\n")
         QMessageBox.information(self._parentWidget(), OpenMWExportPlugin.tr("OpenMW Export Complete"), OpenMWExportPlugin.tr("The export to OpenMW completed successfully. The current setup was saved to {0}").format(configPath))


### PR DESCRIPTION
Added automatic support for .omwaddon, .omwscripts, and .omwgame by creating dummy ESP files on first run. The tool now detects changes and automatically exports updates. Optional performance mode uses a cache to reduce export overhead. Note that you may need to launch Mod Organizer 2 more than once for the dummy ESPs to register correctly.